### PR TITLE
Enable NAT Gateway for GCP

### DIFF
--- a/terraform/gcp/templates/cf_lb.tf
+++ b/terraform/gcp/templates/cf_lb.tf
@@ -233,3 +233,26 @@ resource "google_compute_forwarding_rule" "cf-ws-http" {
   ip_protocol = "TCP"
   ip_address  = "${google_compute_address.cf-ws.address}"
 }
+
+resource "google_compute_router" "router" {
+  name    = "${var.env_id}-router"
+  region  = "${var.region}"
+  network = "${google_compute_network.bbl-network.name}"
+
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_nat" "nat" {
+  name                               = "${var.env_id}-router-nat"
+  router                             = "${google_compute_router.router.name}"
+  region                             = "${var.region}"
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}


### PR DESCRIPTION
* currently we have to use external IPs for all VMs to enable outgoing traffic (`ephemeral_external_ip: true` in BOSH cloud-config)
* to avoid allocating a large number of external IPs (and possibly leaving behind cost-incurring orphans), we should use a NAT gateway instead as on other infrastructures
* this basic NAT configuration is taken from the Terraform manual: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat#example-usage---router-nat-basic